### PR TITLE
refactor [] MemberServiceImpl 이 DIP, OCP 준수하도록 수정

### DIFF
--- a/src/main/java/hsyou/app/MemberApp.java
+++ b/src/main/java/hsyou/app/MemberApp.java
@@ -1,13 +1,16 @@
 package hsyou.app;
 
+import hsyou.config.AppConfig;
 import hsyou.user.Grade;
 import hsyou.user.Member;
 import hsyou.user.MemberService;
-import hsyou.user.MemberServiceImpl;
 
 public class MemberApp {
     public static void main(String[] args) {
-        MemberService memberService = new MemberServiceImpl();
+        AppConfig appConfig = new AppConfig();
+
+        MemberService memberService = appConfig.memberService();
+
         Member member = new Member(1L, "hsyou", Grade.VIP);
 
         memberService.join(member);

--- a/src/main/java/hsyou/config/AppConfig.java
+++ b/src/main/java/hsyou/config/AppConfig.java
@@ -1,0 +1,17 @@
+package hsyou.config;
+
+import hsyou.user.MemberMemoryRepository;
+import hsyou.user.MemberRepository;
+import hsyou.user.MemberService;
+import hsyou.user.MemberServiceImpl;
+
+public class AppConfig {
+
+    public MemberRepository memberRepository() {
+        return new MemberMemoryRepository();
+    }
+
+    public MemberService memberService() {
+        return new MemberServiceImpl(memberRepository());
+    }
+}

--- a/src/main/java/hsyou/user/MemberServiceImpl.java
+++ b/src/main/java/hsyou/user/MemberServiceImpl.java
@@ -2,7 +2,11 @@ package hsyou.user;
 
 public class MemberServiceImpl implements MemberService {
 
-    MemberRepository memberRepository = new MemberMemoryRepository();
+    MemberRepository memberRepository;
+
+    public MemberServiceImpl(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public void join(Member member) {


### PR DESCRIPTION
<img width="592" alt="Screen Shot 2023-04-04 at 8 22 15 PM" src="https://user-images.githubusercontent.com/54466276/229778046-7597bb7a-cfee-44f2-a5c5-d6f56e3c5cd1.png">

### IoC : 제어의 역전
---
위 그림과 같이 AppConfig 의 등장 이전에는 구현 객체(`MemberServiceImpl`,`MemeberMemoryRepository`)가 프로그램의 제어흐름을 스스로 조종했다.

AppConfig 등장 이후, 구현 객체는 자신의 로직을 실행하는 일만 담당하게 되었으며 프로그램의 제어권은 모두 AppConfig 가 가지게 되었다.
구현 객체(`MemberServiceImpl`,`MemeberMemoryRepository`)가 제어했던 의존성 설정제어를 외부(`AppConfig`)에서 제어권을 가져갔다고 해서 제어의 역전(IoC) 이라 칭한다.

**이제 구현 객체는 자신이 의존하는 인터페이스의 구현객체를 직접 설정할 수 없게 되었다.**

### DI : 의존관계 주입
---
**컴파일 시점**이 아닌 **런타임 시점**에 외부(구성영역)에서 실제 구현객체를 생성하여 클라이언트에 전달하여 클라이언트와 실제 구현객체가 연결되는 것을 의존관계 주입이라 한다.

### IoC 컨테이너 (DI 컨테이너)
---
**구성영역**(`AppConfig`) 에서 구현객체를 생성하고 관리하며 DI 를 해주는 것을 IoC 컨테이너라 한다.
최근에는 DI 컨테이너라고 부르는 추세이다.